### PR TITLE
handle case when prices are missing for ab abstract/concrete product

### DIFF
--- a/src/Spryker/Zed/PriceProductStorage/Business/Storage/PriceProductAbstractStorageWriter.php
+++ b/src/Spryker/Zed/PriceProductStorage/Business/Storage/PriceProductAbstractStorageWriter.php
@@ -219,6 +219,7 @@ class PriceProductAbstractStorageWriter implements PriceProductAbstractStorageWr
         $priceProductCriteria = $this->getPriceCriteriaTransfer();
         foreach ($productAbstractIds as $idProductAbstract) {
             $productAbstractPriceProductTransfers = $this->priceProductFacade->findProductAbstractPricesWithoutPriceExtraction($idProductAbstract, $priceProductCriteria);
+            $priceGroups[$idProductAbstract] = [];
             foreach ($productAbstractPriceProductTransfers as $priceProductTransfer) {
                 $storeName = $this->getStoreNameById($priceProductTransfer->getMoneyValue()->getFkStore());
                 $priceGroups[$idProductAbstract][$storeName][] = $priceProductTransfer;

--- a/src/Spryker/Zed/PriceProductStorage/Business/Storage/PriceProductConcreteStorageWriter.php
+++ b/src/Spryker/Zed/PriceProductStorage/Business/Storage/PriceProductConcreteStorageWriter.php
@@ -207,6 +207,7 @@ class PriceProductConcreteStorageWriter implements PriceProductConcreteStorageWr
         $priceProductCriteria = $this->getPriceCriteriaTransfer();
         foreach ($productAbstractIdMap as $idProductConcrete => $idProductAbstract) {
             $productConcretePriceProductTransfers = $this->priceProductFacade->findProductConcretePricesWithoutPriceExtraction($idProductConcrete, $idProductAbstract, $priceProductCriteria);
+            $priceGroups[$idProductConcrete] = [];
             foreach ($productConcretePriceProductTransfers as $priceProductTransfer) {
                 $storeName = $this->getStoreNameById($priceProductTransfer->getMoneyValue()->getFkStore());
                 $priceGroups[$idProductConcrete][$storeName][] = $priceProductTransfer;


### PR DESCRIPTION
just for the record ..

its always possible that a product can get prices for the merchant relation before there is a price without one. this fix prevents the storage writer to then fail and not export any prices to redis.