### PR TITLE
SUPESC-313: Fixed the volume prices for different price types.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": ">=7.1",
     "spryker/event-behavior": "^1.1.0",
     "spryker/kernel": "^3.21.0",
-    "spryker/price-product": "^2.14.0 || ^4.14.0",
+    "spryker/price-product": "^2.15.0 || ^4.23.0",
     "spryker/price-product-storage-extension": "^1.0.0",
     "spryker/product": "^5.5.0 || ^6.0.0",
     "spryker/propel-orm": "^1.5.0",

--- a/src/Spryker/Client/PriceProductStorage/Storage/PriceProductMapper.php
+++ b/src/Spryker/Client/PriceProductStorage/Storage/PriceProductMapper.php
@@ -93,8 +93,15 @@ class PriceProductMapper implements PriceProductMapperInterface
      */
     protected function setPriceData(PriceProductTransfer $priceProductTransfer, array $prices): PriceProductTransfer
     {
+        $moneyValueTransfer = $priceProductTransfer->getMoneyValue();
+
         if (isset($prices[PriceProductStorageConfig::PRICE_DATA])) {
-            $priceProductTransfer->getMoneyValue()->setPriceData($prices[PriceProductStorageConfig::PRICE_DATA]);
+            $priceData = $prices[PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE][$priceProductTransfer->getPriceTypeName()] ?? $prices[PriceProductStorageConfig::PRICE_DATA];
+            $moneyValueTransfer->setPriceData($priceData);
+        }
+
+        if (isset($prices[PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE])) {
+            $moneyValueTransfer->setPriceDataByPriceType($prices[PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE]);
         }
 
         return $priceProductTransfer;

--- a/src/Spryker/Client/PriceProductStorage/Storage/PriceProductMapper.php
+++ b/src/Spryker/Client/PriceProductStorage/Storage/PriceProductMapper.php
@@ -60,8 +60,6 @@ class PriceProductMapper implements PriceProductMapperInterface
         array $prices,
         string $currencyCode
     ): void {
-        $priceProductTransfer = null;
-
         foreach (PriceProductStorageConfig::PRICE_MODES as $priceMode) {
             if (!isset($prices[$priceMode])) {
                 continue;
@@ -110,7 +108,7 @@ class PriceProductMapper implements PriceProductMapperInterface
     /**
      * @param string $currencyCode
      * @param string $priceType
-     * @param array $priceProductTransfers
+     * @param \Generated\Shared\Transfer\PriceProductTransfer[] $priceProductTransfers
      *
      * @return \Generated\Shared\Transfer\PriceProductTransfer
      */

--- a/src/Spryker/Client/PriceProductStorage/Storage/PriceProductMapper.php
+++ b/src/Spryker/Client/PriceProductStorage/Storage/PriceProductMapper.php
@@ -60,6 +60,8 @@ class PriceProductMapper implements PriceProductMapperInterface
         array $prices,
         string $currencyCode
     ): void {
+        $priceProductTransfer = null;
+
         foreach (PriceProductStorageConfig::PRICE_MODES as $priceMode) {
             if (!isset($prices[$priceMode])) {
                 continue;
@@ -93,8 +95,8 @@ class PriceProductMapper implements PriceProductMapperInterface
     {
         $moneyValueTransfer = $priceProductTransfer->getMoneyValue();
 
-        if (isset($prices[PriceProductStorageConfig::PRICE_DATA])) {
-            $priceData = $prices[PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE][$priceProductTransfer->getPriceTypeName()] ?? $prices[PriceProductStorageConfig::PRICE_DATA];
+        $priceData = $this->resolvePriceData($priceProductTransfer, $prices);
+        if ($priceData !== null) {
             $moneyValueTransfer->setPriceData($priceData);
         }
 
@@ -106,9 +108,20 @@ class PriceProductMapper implements PriceProductMapperInterface
     }
 
     /**
+     * @param \Generated\Shared\Transfer\PriceProductTransfer $priceProductTransfer
+     * @param array $prices
+     *
+     * @return string|null
+     */
+    protected function resolvePriceData(PriceProductTransfer $priceProductTransfer, array $prices): ?string
+    {
+        return $prices[PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE][$priceProductTransfer->getPriceTypeName()] ?? $prices[PriceProductStorageConfig::PRICE_DATA] ?? null;
+    }
+
+    /**
      * @param string $currencyCode
      * @param string $priceType
-     * @param \Generated\Shared\Transfer\PriceProductTransfer[] $priceProductTransfers
+     * @param array $priceProductTransfers
      *
      * @return \Generated\Shared\Transfer\PriceProductTransfer
      */

--- a/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
+++ b/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\AbstractSharedConfig;
 class PriceProductStorageConfig extends AbstractSharedConfig
 {
     /**
-     * @deprecated Use {@link PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE} instead.
+     * @deprecated Use {@link \Spryker\Shared\PriceProductStorage\PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE} instead.
      *
      * @see \Spryker\Shared\PriceProduct\PriceProductConfig::PRICE_DATA
      */

--- a/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
+++ b/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\AbstractSharedConfig;
 class PriceProductStorageConfig extends AbstractSharedConfig
 {
     /**
-     * @deprecated Use {@link \Spryker\Shared\PriceProductStorage\PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE} instead.
+     * @deprecated Use {@link PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE} instead.
      *
      * @see \Spryker\Shared\PriceProduct\PriceProductConfig::PRICE_DATA
      */

--- a/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
+++ b/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
@@ -12,9 +12,16 @@ use Spryker\Shared\Kernel\AbstractSharedConfig;
 class PriceProductStorageConfig extends AbstractSharedConfig
 {
     /**
+     * @deprecated Use {@link \Spryker\Shared\PriceProductStorage\PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE} instead.
+     *
      * @see \Spryker\Shared\PriceProduct\PriceProductConfig::PRICE_DATA
      */
     public const PRICE_DATA = 'priceData';
+
+    /**
+     * @uses \Spryker\Shared\PriceProduct\PriceProductConfig::PRICE_DATA_BY_PRICE_TYPE
+     */
+    public const PRICE_DATA_BY_PRICE_TYPE = 'priceDataByPriceType';
 
     /**
      * @see \Spryker\Shared\Price\PriceConfig::PRICE_MODE_NET

--- a/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
+++ b/src/Spryker/Shared/PriceProductStorage/PriceProductStorageConfig.php
@@ -12,8 +12,6 @@ use Spryker\Shared\Kernel\AbstractSharedConfig;
 class PriceProductStorageConfig extends AbstractSharedConfig
 {
     /**
-     * @deprecated Use {@link \Spryker\Shared\PriceProductStorage\PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE} instead.
-     *
      * @see \Spryker\Shared\PriceProduct\PriceProductConfig::PRICE_DATA
      */
     public const PRICE_DATA = 'priceData';

--- a/src/Spryker/Shared/PriceProductStorage/Transfer/price_product_storage.transfer.xml
+++ b/src/Spryker/Shared/PriceProductStorage/Transfer/price_product_storage.transfer.xml
@@ -22,6 +22,7 @@
 
     <transfer name="MoneyValue">
         <property name="priceData" type="string" />
+        <property name="priceDataByPriceType" type="array" singular="priceDataByPriceType"/>
     </transfer>
 
     <transfer name="PriceProductFilter">

--- a/src/Spryker/Shared/PriceProductStorage/Transfer/price_product_storage.transfer.xml
+++ b/src/Spryker/Shared/PriceProductStorage/Transfer/price_product_storage.transfer.xml
@@ -7,6 +7,7 @@
         <property name="moneyValue" type="MoneyValue" />
         <property name="groupKey" type="string" />
         <property name="isMergeable" type="bool" />
+        <property name="priceTypeName" type="string"/>
     </transfer>
 
     <transfer name="PriceProductStorage">


### PR DESCRIPTION
Branch: backport/supesc-313/price-product-storage-2.17.0
Ticket: https://spryker.atlassian.net/browse/SUPESC-313
Target Version: 2.17.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   PriceProductStorage               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module PriceProductStorage

##### Change log

Improvements

- Introduced `MoneyValueTransfer.priceDataByPriceType` transfer property.
- Introduced `PriceProductStorageConfig::PRICE_DATA_BY_PRICE_TYPE`.
- Adjusted `PriceProductStorageClient::getPriceProductAbstractTransfers()`, `PriceProductStorageClient::getPriceProductConcreteTransfers()` and `PriceProductStorageClient::getResolvedPriceProductConcreteTransfers()` so now every returned `PriceProductTransfer` contains price data by price type if it's defined.
